### PR TITLE
Compatibility with newer PHPUnit versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - composer update
 
 script:
-  - ./vendor/bin/phpunit --disallow-test-output --report-useless-tests --coverage-clover ./clover.xml
+  - ./vendor/bin/phpunit --disallow-test-output  --coverage-clover ./clover.xml
   - ./finalizer finalizer:check-final-classes src
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7
-  - hhvm
-  - hhvm-nightly
+  - 7.2
+  - nightly
 
 before_script:
   - composer self-update
@@ -16,9 +14,7 @@ script:
 
 matrix:
   allow_failures:
-    - php: 7
-    - php: hhvm
-    - php: hhvm-nightly
+    - php: nightly
 
 after_script:
   - sh .travis.coverage.sh

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/console": "~2.6|~3.0|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "~7.0"
     },
     "bin": [
         "finalizer"

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
         }
     },
     "require": {
-        "php":             "~5.6|~7.0",
-        "symfony/console": "~2.6|~3.0"
+        "php":             "~5.6|~7.0|~7.1",
+        "symfony/console": "~2.6|~3.0|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~5.0"
     },
     "bin": [
         "finalizer"

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
         }
     },
     "require": {
-        "php":             "~5.6|~7.0|~7.1",
+        "php":             "~7.2",
         "symfony/console": "~2.6|~3.0|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~6.0"
     },
     "bin": [
         "finalizer"

--- a/test/FinalizerTest/Console/CheckFinalClassesCommandTest.php
+++ b/test/FinalizerTest/Console/CheckFinalClassesCommandTest.php
@@ -3,15 +3,14 @@
 namespace FinalizerTest\Console;
 
 use Finalizer\Console\CheckFinalClassesCommand;
-use FinalizerTestAsset\Finalizable;
-use FinalizerTestAsset\NonFinalizable;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
 
 /**
  * @covers \Finalizer\Console\CheckFinalClassesCommand
  */
-class CheckFinalClassesCommandTest extends \PHPUnit_Framework_TestCase
+class CheckFinalClassesCommandTest extends TestCase
 {
     /**
      * @dataProvider pathsProvider

--- a/test/FinalizerTest/Constraint/IsFinalizableTest.php
+++ b/test/FinalizerTest/Constraint/IsFinalizableTest.php
@@ -5,11 +5,12 @@ namespace FinalizerTest\Constraint;
 use Finalizer\Constraint\IsFinalizable;
 use FinalizerTestAsset\Finalizable;
 use FinalizerTestAsset\NonFinalizable;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Finalizer\Constraint\IsFinalizable
  */
-class IsFinalizableTest extends \PHPUnit_Framework_TestCase
+class IsFinalizableTest extends TestCase
 {
     /**
      * @dataProvider finalizableClassesProvider

--- a/test/FinalizerTest/Iterator/MapIteratorTest.php
+++ b/test/FinalizerTest/Iterator/MapIteratorTest.php
@@ -3,18 +3,19 @@
 namespace FinalizerTest\Reflection;
 
 use Finalizer\Iterator\MapIterator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Finalizer\Iterator\MapIterator
  */
-class MapIteratorTest extends \PHPUnit_Framework_TestCase
+class MapIteratorTest extends TestCase
 {
     public function testCurrent()
     {
         /* @var $map callable|\PHPUnit_Framework_MockObject_MockObject */
-        $map             = $this->getMock(\stdClass::class, ['__invoke']);
+        $map             = $this->createPartialMock(\stdClass::class, ['__invoke']);
         /* @var $wrappedIterator \Iterator|\PHPUnit_Framework_MockObject_MockObject */
-        $wrappedIterator = $this->getMock(\Iterator::class);
+        $wrappedIterator = $this->createMock(\Iterator::class);
 
         $wrappedIterator->expects($this->at(0))->method('current')->will($this->returnValue('foo'));
         $wrappedIterator->expects($this->at(1))->method('current')->will($this->returnValue('bar'));
@@ -31,9 +32,9 @@ class MapIteratorTest extends \PHPUnit_Framework_TestCase
     public function testNext()
     {
         /* @var $map callable|\PHPUnit_Framework_MockObject_MockObject */
-        $map             = $this->getMock(\stdClass::class, ['__invoke']);
+        $map             = $this->createPartialMock(\stdClass::class, ['__invoke']);
         /* @var $wrappedIterator \Iterator|\PHPUnit_Framework_MockObject_MockObject */
-        $wrappedIterator = $this->getMock(\Iterator::class);
+        $wrappedIterator = $this->createMock(\Iterator::class);
 
         $wrappedIterator->expects($this->exactly(2))->method('next');
 
@@ -48,9 +49,9 @@ class MapIteratorTest extends \PHPUnit_Framework_TestCase
     public function testRewind()
     {
         /* @var $map callable|\PHPUnit_Framework_MockObject_MockObject */
-        $map             = $this->getMock(\stdClass::class, ['__invoke']);
+        $map             = $this->createPartialMock(\stdClass::class, ['__invoke']);
         /* @var $wrappedIterator \Iterator|\PHPUnit_Framework_MockObject_MockObject */
-        $wrappedIterator = $this->getMock(\Iterator::class);
+        $wrappedIterator = $this->createMock(\Iterator::class);
 
         $wrappedIterator->expects($this->exactly(2))->method('rewind');
 
@@ -65,9 +66,9 @@ class MapIteratorTest extends \PHPUnit_Framework_TestCase
     public function testKey()
     {
         /* @var $map callable|\PHPUnit_Framework_MockObject_MockObject */
-        $map             = $this->getMock(\stdClass::class, ['__invoke']);
+        $map             = $this->createPartialMock(\stdClass::class, ['__invoke']);
         /* @var $wrappedIterator \Iterator|\PHPUnit_Framework_MockObject_MockObject */
-        $wrappedIterator = $this->getMock(\Iterator::class);
+        $wrappedIterator = $this->createMock(\Iterator::class);
 
         $wrappedIterator->expects($this->at(0))->method('key')->will($this->returnValue('foo'));
         $wrappedIterator->expects($this->at(1))->method('key')->will($this->returnValue('bar'));
@@ -83,9 +84,9 @@ class MapIteratorTest extends \PHPUnit_Framework_TestCase
     public function testValid()
     {
         /* @var $map callable|\PHPUnit_Framework_MockObject_MockObject */
-        $map             = $this->getMock(\stdClass::class, ['__invoke']);
+        $map             = $this->createPartialMock(\stdClass::class, ['__invoke']);
         /* @var $wrappedIterator \Iterator|\PHPUnit_Framework_MockObject_MockObject */
-        $wrappedIterator = $this->getMock(\Iterator::class);
+        $wrappedIterator = $this->createMock(\Iterator::class);
 
         $wrappedIterator->expects($this->at(0))->method('valid')->will($this->returnValue(true));
         $wrappedIterator->expects($this->at(1))->method('valid')->will($this->returnValue(false));

--- a/test/FinalizerTest/Reflection/InheritanceClassesTest.php
+++ b/test/FinalizerTest/Reflection/InheritanceClassesTest.php
@@ -3,11 +3,12 @@
 namespace FinalizerTest\Reflection;
 
 use Finalizer\Reflection\InheritanceClasses;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Finalizer\Reflection\InheritanceClasses
  */
-class InheritanceClassesTest extends \PHPUnit_Framework_TestCase
+class InheritanceClassesTest extends TestCase
 {
     /**
      * @dataProvider classesProvider

--- a/test/FinalizerTest/Scanner/DirectoryClassScannerTest.php
+++ b/test/FinalizerTest/Scanner/DirectoryClassScannerTest.php
@@ -3,11 +3,12 @@
 namespace FinalizerTest\Scanner;
 
 use Finalizer\Scanner\DirectoryClassScanner;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Finalizer\Scanner\DirectoryClassScanner
  */
-class DirectoryClassScannerTest extends \PHPUnit_Framework_TestCase
+class DirectoryClassScannerTest extends TestCase
 {
     /**
      * @dataProvider pathsProvider

--- a/test/FinalizerTest/Scanner/DirectoryFileScannerTest.php
+++ b/test/FinalizerTest/Scanner/DirectoryFileScannerTest.php
@@ -4,11 +4,12 @@ namespace FinalizerTest\Scanner;
 
 use Finalizer\Scanner\DirectoryClassScanner;
 use Finalizer\Scanner\DirectoryFileScanner;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Finalizer\Scanner\DirectoryFileScanner
  */
-class DirectoryFileScannerTest extends \PHPUnit_Framework_TestCase
+class DirectoryFileScannerTest extends TestCase
 {
     /**
      * @dataProvider pathsProvider


### PR DESCRIPTION
I upgraded also to phpunit due deprecation for `each`


```
PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in /var/www/Finalizer/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38
PHP Stack trace:
PHP   1. {main}() /var/www/Finalizer/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main($exit = *uninitialized*) /var/www/Finalizer/vendor/phpunit/phpunit/phpunit:52
PHP   3. PHPUnit_TextUI_Command->run($argv = *uninitialized*, $exit = *uninitialized*) /var/www/Finalizer/vendor/phpunit/phpunit/src/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_Command->handleArguments($argv = *uninitialized*) /var/www/Finalizer/vendor/phpunit/phpunit/src/TextUI/Command.php:111
PHP   5. PHPUnit_Util_Getopt::getopt($args = *uninitialized*, $short_options = *uninitialized*, $long_options = *uninitialized*) /var/www/Finalizer/vendor/phpunit/phpunit/src/TextUI/Command.php:240
PHP   6. each(*uninitialized*) /var/www/Finalizer/vendor/phpunit/phpunit/src/Util/Getopt.php:38

Deprecated: The each() function is deprecated. This message will be suppressed on further calls in /var/www/Finalizer/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38

Call Stack:
    0.0085     393632   1. {main}() /var/www/Finalizer/vendor/phpunit/phpunit/phpunit:0
    0.1071     726208   2. PHPUnit_TextUI_Command::main(???) /var/www/Finalizer/vendor/phpunit/phpunit/phpunit:52
    0.1071     726320   3. PHPUnit_TextUI_Command->run(???, ???) /var/www/Finalizer/vendor/phpunit/phpunit/src/TextUI/Command.php:100
    0.1071     726320   4. PHPUnit_TextUI_Command->handleArguments(???) /var/www/Finalizer/vendor/phpunit/phpunit/src/TextUI/Command.php:111
    0.1093     755088   5. PHPUnit_Util_Getopt::getopt(???, ???, ???) /var/www/Finalizer/vendor/phpunit/phpunit/src/TextUI/Command.php:240
    0.1093     755512   6. each(???) /var/www/Finalizer/vendor/phpunit/phpunit/src/Util/Getopt.php:38
