### PR TITLE
Use PSR-4 for autoloading, PSR-0 is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "Finalizer\\": "src"
+        "psr-4": {
+            "Finalizer\\": "src/Finalizer"
         }
     },
     "autoload-dev": {
-        "psr-0": {
-            "FinalizerTest\\":      "test",
-            "FinalizerTestAsset\\": "test"
+        "psr-4": {
+            "FinalizerTest\\":      "test/FinalizerTest/",
+            "FinalizerTestAsset\\": "test/FinalizerTestAsset/"
         }
     },
     "require": {


### PR DESCRIPTION
Since 2014-10-21 PSR-0 is deprecated. It is recommended to use PSR-4 as an alternative.
[source](https://www.php-fig.org/psr/psr-0/)